### PR TITLE
Resolve bug with cache mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### v2.0.4 (2018/4/20)
+
+**Bug Fixes**
+
+* Fixes a bug where there could be a cache mismatch when re-rendering the same component
+  that has a fetch policy configured.
+
 ### v2.0.3 (2018/3/2)
 
 **Bug Fixes**

--- a/README.md
+++ b/README.md
@@ -225,8 +225,9 @@ There are three common use cases for the `doFetch` prop:
   is passed as `true`.
 
 `doFetch` accepts one argument: `options`. Any of the `fetch()` options, such as `url`, `method`, and
-`body` are valid `options`. This allows you to customize the request from within the component based
-on the component's state.
+`body` are valid `options`. You may also specify a new `requestKey` if you are manually generating your
+own keys. This method allows you to customize the request from within the component based on the
+component's state.
 
 ##### `lazy`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-request",
-  "version": "2.0.4-beta.3",
+  "version": "2.0.4",
   "description": "Declarative HTTP requests with React.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-request",
-  "version": "2.0.4-beta.1",
+  "version": "2.0.4-beta.2",
   "description": "Declarative HTTP requests with React.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-request",
-  "version": "2.0.3",
+  "version": "2.0.4-beta.1",
   "description": "Declarative HTTP requests with React.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-request",
-  "version": "2.0.4-beta.2",
+  "version": "2.0.4-beta.3",
   "description": "Declarative HTTP requests with React.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -13,8 +13,8 @@ export function clearResponseCache() {
 
 export class Fetch extends React.Component {
   render() {
-    const { children, requestName, url } = this.props;
-    const { fetching, response, data, error, requestKey } = this.state;
+    const { children, requestName } = this.props;
+    const { fetching, response, data, error, requestKey, url } = this.state;
 
     if (!children) {
       return null;
@@ -49,7 +49,8 @@ export class Fetch extends React.Component {
       fetching: false,
       response: null,
       data: null,
-      error: null
+      error: null,
+      url: props.url || ''
     };
   }
 
@@ -197,10 +198,9 @@ export class Fetch extends React.Component {
     // `options` when calling `doFetch()`. Perhaps we should, however.
     const { requestName, dedupe, beforeFetch } = this.props;
 
-    this.cancelExistingRequest('New fetch initiated', this.props);
+    this.cancelExistingRequest('New fetch initiated');
 
-    const requestKey = this.getRequestKey(this.props, options);
-
+    const requestKey = this.getRequestKey(options);
     const requestOptions = Object.assign({}, this.props, options);
 
     const {
@@ -249,6 +249,7 @@ export class Fetch extends React.Component {
     // If the request config changes, we need to be able to accurately
     // cancel the in-flight request.
     this.responseReceivedInfo = responseReceivedInfo;
+
     this.hasHandledNetworkResponse = false;
 
     const fetchPolicy = this.getFetchPolicy();
@@ -287,6 +288,9 @@ export class Fetch extends React.Component {
       // may be duplicated in those situations, but that should be OK. It is necessary
       // to include this here to account for "network-only" fetch policies.
       requestKey,
+      url,
+      error: null,
+      failed: false,
       fetching: true
     });
     const hittingNetwork = !isRequestInFlight(requestKey) || !dedupe;
@@ -379,6 +383,7 @@ export class Fetch extends React.Component {
 
     this.setState(
       {
+        url,
         data,
         error,
         response,

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -50,7 +50,7 @@ export class Fetch extends React.Component {
       response: null,
       data: null,
       error: null,
-      url: props.url || ''
+      url: props.url
     };
   }
 

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -7,5 +7,8 @@
     "ecmaFeatures": {
       "jsx": true
     }
+  },
+  "globals": {
+    "hangingPromise": true
   }
 }

--- a/test/do-fetch.test.js
+++ b/test/do-fetch.test.js
@@ -1,0 +1,412 @@
+import React from 'react';
+import fetchMock from 'fetch-mock';
+import { mount } from 'enzyme';
+import { Fetch, clearRequestCache, clearResponseCache } from '../src';
+
+// Some time for the mock fetches to resolve
+const networkTimeout = 10;
+
+beforeEach(() => {
+  clearRequestCache();
+  clearResponseCache();
+});
+
+describe('same-component doFetch() with caching (gh-151)', () => {
+  test('doFetch() with URL and another HTTP method', done => {
+    // expect.assertions(8);
+    const onResponseMock = jest.fn();
+    const beforeFetchMock = jest.fn();
+    const afterFetchMock = jest.fn();
+
+    let run = 1;
+    let renderCount = 0;
+
+    mount(
+      <Fetch
+        url="/test/succeeds/json-one"
+        requestKey="1"
+        beforeFetch={beforeFetchMock}
+        afterFetch={afterFetchMock}
+        onResponse={onResponseMock}>
+        {options => {
+          renderCount++;
+
+          // Wait for things to be placed in the cache.
+          // This occurs on the third render:
+          // 1st. component mounts
+          // 2nd. fetch begins
+          // 3rd. fetch ends
+          if (run === 1 && renderCount === 3) {
+            expect(options).toEqual(expect.objectContaining({
+              fetching: false,
+              data: {
+                books: [1, 42, 150]
+              },
+              error: null,
+              failed: false,
+              requestName: 'anonymousRequest',
+              url: '/test/succeeds/json-one'
+            }));
+
+            // We need a timeout here to prevent a race condition
+            // with the assertions after the component mounts.
+            setTimeout(() => {
+              run++;
+              renderCount = 0;
+              options.doFetch({
+                method: 'patch',
+                url: '/test/succeeds/patch'
+              });
+
+              // Now we need another timeout to allow for the fetch
+              // to occur.
+              setTimeout(() => {
+                done();
+              }, networkTimeout);
+            }, networkTimeout * 2);
+          }
+
+          if (run === 2) {
+            if (renderCount === 1) {
+              expect(options).toEqual(expect.objectContaining({
+                fetching: true,
+                data: {
+                  books: [1, 42, 150]
+                },
+                error: null,
+                failed: false,
+                requestName: 'anonymousRequest',
+                url: '/test/succeeds/patch'
+              }));
+            }
+            if (renderCount === 2) {
+              expect(fetchMock.calls('/test/succeeds/patch').length).toBe(1);
+              expect(options).toEqual(expect.objectContaining({
+                fetching: false,
+                data: {
+                  movies: [1]
+                },
+                error: null,
+                failed: false,
+                requestName: 'anonymousRequest',
+                url: '/test/succeeds/patch'
+              }));
+            }
+            if (renderCount === 3) {
+              done.fail();
+            }
+          }
+        }}
+      </Fetch>
+    );
+
+    setTimeout(() => {
+      // NOTE: this is for adding stuff to the cache.
+      // This DOES NOT test the cache-only behavior!
+      expect(fetchMock.calls('/test/succeeds/json-one').length).toBe(1);
+      expect(beforeFetchMock).toHaveBeenCalledTimes(1);
+      expect(afterFetchMock).toHaveBeenCalledTimes(1);
+      expect(afterFetchMock).toBeCalledWith(
+        expect.objectContaining({
+          url: '/test/succeeds/json-one',
+          error: null,
+          failed: false,
+          didUnmount: false,
+          data: {
+            books: [1, 42, 150]
+          }
+        })
+      );
+      expect(onResponseMock).toHaveBeenCalledTimes(1);
+      expect(onResponseMock).toBeCalledWith(
+        null,
+        expect.objectContaining({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          data: {
+            books: [1, 42, 150]
+          }
+        })
+      );
+    }, networkTimeout);
+  });
+
+  test('doFetch() with request key and URL', done => {
+    // expect.assertions(8);
+    const onResponseMock = jest.fn();
+    const beforeFetchMock = jest.fn();
+    const afterFetchMock = jest.fn();
+
+    let run = 1;
+    let renderCount = 0;
+
+    mount(
+      <Fetch
+        url="/test/succeeds/json-one"
+        requestKey="1"
+        beforeFetch={beforeFetchMock}
+        afterFetch={afterFetchMock}
+        onResponse={onResponseMock}>
+        {options => {
+          renderCount++;
+
+          // Wait for things to be placed in the cache.
+          // This occurs on the third render:
+          // 1st. component mounts
+          // 2nd. fetch begins
+          // 3rd. fetch ends
+          if (run === 1 && renderCount === 3) {
+            expect(options).toEqual(expect.objectContaining({
+              fetching: false,
+              data: {
+                books: [1, 42, 150]
+              },
+              error: null,
+              failed: false,
+              requestName: 'anonymousRequest',
+              url: '/test/succeeds/json-one'
+            }));
+
+            // We need a timeout here to prevent a race condition
+            // with the assertions after the component mounts.
+            setTimeout(() => {
+              run++;
+              renderCount = 0;
+
+              options.doFetch({
+                requestKey: 'sandwiches',
+                url: '/test/succeeds/json-two'
+              });
+
+              // Now we need another timeout to allow for the fetch
+              // to occur.
+              setTimeout(() => {
+                done();
+              }, networkTimeout);
+            }, networkTimeout * 2);
+          }
+
+          if (run === 2) {
+            if (renderCount === 1) {
+              expect(options).toEqual(expect.objectContaining({
+                fetching: true,
+                data: {
+                  books: [1, 42, 150]
+                },
+                error: null,
+                failed: false,
+                requestKey: 'sandwiches',
+                requestName: 'anonymousRequest',
+                url: '/test/succeeds/json-two'
+              }));
+            }
+            if (renderCount === 2) {
+              expect(options).toEqual(expect.objectContaining({
+                fetching: false,
+                data: {
+                  authors: [22, 13]
+                },
+                error: null,
+                failed: false,
+                requestKey: 'sandwiches',
+                requestName: 'anonymousRequest',
+                url: '/test/succeeds/json-two'
+              }));
+            }
+            if (renderCount === 3) {
+              done.fail();
+            }
+          }
+        }}
+      </Fetch>
+    );
+
+    setTimeout(() => {
+      // NOTE: this is for adding stuff to the cache.
+      // This DOES NOT test the cache-only behavior!
+      expect(fetchMock.calls('/test/succeeds/json-one').length).toBe(1);
+      expect(beforeFetchMock).toHaveBeenCalledTimes(1);
+      expect(afterFetchMock).toHaveBeenCalledTimes(1);
+      expect(afterFetchMock).toBeCalledWith(
+        expect.objectContaining({
+          url: '/test/succeeds/json-one',
+          error: null,
+          failed: false,
+          didUnmount: false,
+          data: {
+            books: [1, 42, 150]
+          }
+        })
+      );
+      expect(onResponseMock).toHaveBeenCalledTimes(1);
+      expect(onResponseMock).toBeCalledWith(
+        null,
+        expect.objectContaining({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          data: {
+            books: [1, 42, 150]
+          }
+        })
+      );
+    }, networkTimeout);
+  });
+
+  // Note: this does not test dedupe due to the fact that the requests
+  // resolve too quickly.
+  test('doFetch(); testing cancelation', done => {
+    // expect.assertions(8);
+    const onResponseMock = jest.fn();
+    const beforeFetchMock = jest.fn();
+    const afterFetchMock = jest.fn();
+
+    let run = 1;
+    let renderCount = 0;
+
+    mount(
+      <Fetch
+        url="/test/succeeds/json-one"
+        requestKey="1"
+        beforeFetch={beforeFetchMock}
+        afterFetch={afterFetchMock}
+        onResponse={onResponseMock}>
+        {options => {
+          renderCount++;
+
+          // Wait for things to be placed in the cache.
+          // This occurs on the third render:
+          // 1st. component mounts
+          // 2nd. fetch begins
+          // 3rd. fetch ends
+          if (run === 1 && renderCount === 3) {
+            expect(options).toEqual(expect.objectContaining({
+              fetching: false,
+              data: {
+                books: [1, 42, 150]
+              },
+              error: null,
+              failed: false,
+              requestName: 'anonymousRequest',
+              url: '/test/succeeds/json-one'
+            }));
+
+            // We need a timeout here to prevent a race condition
+            // with the assertions after the component mounts.
+            setTimeout(() => {
+              run++;
+              renderCount = 0;
+
+              options.doFetch({
+                requestKey: 'sandwiches',
+                url: '/test/succeeds/json-two'
+              });
+
+              options.doFetch({
+                requestKey: 'sandwiches',
+                url: '/test/succeeds/json-two'
+              });
+
+              // Now we need another timeout to allow for the fetch
+              // to occur.
+              setTimeout(() => {
+                done();
+              }, networkTimeout);
+            }, networkTimeout * 2);
+          }
+
+          if (run === 2) {
+            if (renderCount === 1) {
+              expect(options).toEqual(expect.objectContaining({
+                fetching: true,
+                data: {
+                  books: [1, 42, 150]
+                },
+                error: null,
+                failed: false,
+                requestKey: 'sandwiches',
+                requestName: 'anonymousRequest',
+                url: '/test/succeeds/json-two'
+              }));
+            }
+            if (renderCount === 2) {
+              expect(options).toEqual(expect.objectContaining({
+                fetching: false,
+                // I am not sure if I like this behavior!
+                // See gh-154 for more
+                data: null,
+                failed: true,
+                requestKey: 'sandwiches',
+                requestName: 'anonymousRequest',
+                url: '/test/succeeds/json-two'
+              }));
+            }
+
+            // This is the 2nd doFetch(). It is difficult to update
+            // the `run` for that fetch, so we just use the renderCounts.
+            else if (renderCount === 3) {
+              expect(options).toEqual(expect.objectContaining({
+                fetching: true,
+                data: null,
+                error: null,
+                failed: false,
+                requestKey: 'sandwiches',
+                requestName: 'anonymousRequest',
+                url: '/test/succeeds/json-two'
+              }));
+            }
+
+            else if (renderCount === 4) {
+              expect(options).toEqual(expect.objectContaining({
+                fetching: false,
+                data: {
+                  authors: [22, 13]
+                },
+                error: null,
+                failed: false,
+                requestKey: 'sandwiches',
+                requestName: 'anonymousRequest',
+                url: '/test/succeeds/json-two'
+              }));
+            }
+            if (renderCount > 4) {
+              done.fail();
+            }
+          }
+        }}
+      </Fetch>
+    );
+
+    setTimeout(() => {
+      // NOTE: this is for adding stuff to the cache.
+      // This DOES NOT test the cache-only behavior!
+      expect(fetchMock.calls('/test/succeeds/json-one').length).toBe(1);
+      expect(beforeFetchMock).toHaveBeenCalledTimes(1);
+      expect(afterFetchMock).toHaveBeenCalledTimes(1);
+      expect(afterFetchMock).toBeCalledWith(
+        expect.objectContaining({
+          url: '/test/succeeds/json-one',
+          error: null,
+          failed: false,
+          didUnmount: false,
+          data: {
+            books: [1, 42, 150]
+          }
+        })
+      );
+      expect(onResponseMock).toHaveBeenCalledTimes(1);
+      expect(onResponseMock).toBeCalledWith(
+        null,
+        expect.objectContaining({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          data: {
+            books: [1, 42, 150]
+          }
+        })
+      );
+    }, networkTimeout);
+  });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,7 +7,7 @@ import {
   getRequestKey,
   clearResponseCache
 } from '../src';
-import { successfulResponse, jsonResponse } from './responses';
+import { successfulResponse, jsonResponse, jsonResponse2 } from './responses';
 import { setTimeout } from 'timers';
 
 function hangingPromise() {
@@ -67,6 +67,22 @@ fetchMock.post(
   () =>
     new Promise(resolve => {
       resolve(jsonResponse());
+    })
+);
+
+fetchMock.get(
+  '/test/succeeds/json-one',
+  () =>
+    new Promise(resolve => {
+      resolve(jsonResponse());
+    })
+);
+
+fetchMock.get(
+  '/test/succeeds/json-two',
+  () =>
+    new Promise(resolve => {
+      resolve(jsonResponse2());
     })
 );
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,28 +7,7 @@ import {
   getRequestKey,
   clearResponseCache
 } from '../src';
-import { successfulResponse, jsonResponse, jsonResponse2 } from './responses';
-import { setTimeout } from 'timers';
-
-function hangingPromise() {
-  return new Promise(() => {});
-}
-
-fetchMock.get('/test/hangs', hangingPromise());
-fetchMock.get('/test/hangs/1', hangingPromise());
-fetchMock.get('/test/hangs/2', hangingPromise());
-fetchMock.post('/test/hangs', hangingPromise());
-fetchMock.put('/test/hangs', hangingPromise());
-fetchMock.patch('/test/hangs', hangingPromise());
-fetchMock.head('/test/hangs', hangingPromise());
-fetchMock.delete('/test/hangs', hangingPromise());
-
-// This could be improved by adding the URL to the JSON response
-fetchMock.get('/test/succeeds', () => {
-  return new Promise(resolve => {
-    resolve(jsonResponse());
-  });
-});
+import { successfulResponse, jsonResponse } from './responses';
 
 let success = true;
 // This could be improved by adding the URL to the JSON response
@@ -45,46 +24,6 @@ fetchMock.get('/test/variable', () => {
     });
   }
 });
-
-fetchMock.get(
-  '/test/succeeds/cache-only-empty',
-  () =>
-    new Promise(resolve => {
-      resolve(successfulResponse());
-    })
-);
-
-fetchMock.get(
-  '/test/succeeds/cache-only-full',
-  () =>
-    new Promise(resolve => {
-      resolve(jsonResponse());
-    })
-);
-
-fetchMock.post(
-  '/test/succeeds/cache-only-full',
-  () =>
-    new Promise(resolve => {
-      resolve(jsonResponse());
-    })
-);
-
-fetchMock.get(
-  '/test/succeeds/json-one',
-  () =>
-    new Promise(resolve => {
-      resolve(jsonResponse());
-    })
-);
-
-fetchMock.get(
-  '/test/succeeds/json-two',
-  () =>
-    new Promise(resolve => {
-      resolve(jsonResponse2());
-    })
-);
 
 // Some time for the mock fetches to resolve
 const networkTimeout = 10;

--- a/test/responses.js
+++ b/test/responses.js
@@ -11,3 +11,10 @@ export function jsonResponse() {
     statusText: 'OK'
   });
 }
+
+export function jsonResponse2() {
+  return new Response('{"authors": [22, 13]}', {
+    status: 200,
+    statusText: 'OK'
+  });
+}

--- a/test/responses.js
+++ b/test/responses.js
@@ -18,3 +18,10 @@ export function jsonResponse2() {
     statusText: 'OK'
   });
 }
+
+export function jsonResponse3() {
+  return new Response('{"movies": [1]}', {
+    status: 200,
+    statusText: 'OK'
+  });
+}

--- a/test/same-component.test.js
+++ b/test/same-component.test.js
@@ -1,0 +1,244 @@
+import React from 'react';
+import fetchMock from 'fetch-mock';
+import { mount } from 'enzyme';
+import { Fetch, clearRequestCache, clearResponseCache } from '../src';
+import { jsonResponse, jsonResponse2 } from './responses';
+import { setTimeout } from 'timers';
+
+fetchMock.get(
+  '/test/succeeds/json-one',
+  () =>
+    new Promise(resolve => {
+      resolve(jsonResponse());
+    })
+);
+
+fetchMock.get(
+  '/test/succeeds/json-two',
+  () =>
+    new Promise(resolve => {
+      resolve(jsonResponse2());
+    })
+);
+
+// Some time for the mock fetches to resolve
+const networkTimeout = 10;
+
+beforeEach(() => {
+  clearRequestCache();
+  clearResponseCache();
+});
+
+describe('same-component subsequent requests with caching (gh-151)', () => {
+  // Issue 151 describes the 3 situations when requests can be made. "Prop changes"
+  // refers to situation 2.
+  describe('prop changes', () => {
+    test('it uses a directly-updated request key on subsequent renders', done => {
+      // expect.assertions(8);
+      const onResponseMock = jest.fn();
+      const beforeFetchMock = jest.fn();
+      const afterFetchMock = jest.fn();
+
+      let secondRun = false;
+      let secondRenderCount = 0;
+
+      const wrapper = mount(
+        <Fetch
+          url="/test/succeeds/json-one"
+          requestKey="1"
+          beforeFetch={beforeFetchMock}
+          afterFetch={afterFetchMock}
+          onResponse={onResponseMock}>
+          {options => {
+            if (secondRun) {
+              // Increment our render count. This allows us to
+              // test for each of the individual renders involved
+              // with changing the prop.
+              secondRenderCount++;
+
+              // This first render is interesting: we basically only have a
+              // new URL set, but the request has not yet begun. The reason
+              // for this is because we do the fetch in `componentDidUpdate`.
+              if (secondRenderCount === 1) {
+                expect(options).toEqual(
+                  expect.objectContaining({
+                    requestKey: '1',
+                    fetching: false,
+                    data: {
+                      books: [1, 42, 150]
+                    },
+                    error: null,
+                    failed: false,
+                    url: '/test/succeeds/json-two'
+                  })
+                );
+              } else if (secondRenderCount === 2) {
+                expect(options).toEqual(
+                  expect.objectContaining({
+                    requestKey: '2',
+                    fetching: true,
+                    data: {
+                      books: [1, 42, 150]
+                    },
+                    error: null,
+                    failed: false,
+                    url: '/test/succeeds/json-two'
+                  })
+                );
+              } else if (secondRenderCount === 3) {
+                expect(options).toEqual(
+                  expect.objectContaining({
+                    requestKey: '2',
+                    fetching: false,
+                    data: {
+                      authors: [22, 13]
+                    },
+                    error: null,
+                    failed: false,
+                    url: '/test/succeeds/json-two'
+                  })
+                );
+              }
+            }
+          }}
+        </Fetch>
+      );
+
+      setTimeout(() => {
+        // NOTE: this is for adding stuff to the cache.
+        // This DOES NOT test the cache-only behavior!
+        expect(fetchMock.calls('/test/succeeds/json-one').length).toBe(1);
+        expect(beforeFetchMock).toHaveBeenCalledTimes(1);
+        expect(afterFetchMock).toHaveBeenCalledTimes(1);
+        expect(afterFetchMock).toBeCalledWith(
+          expect.objectContaining({
+            url: '/test/succeeds/json-one',
+            error: null,
+            failed: false,
+            didUnmount: false,
+            data: {
+              books: [1, 42, 150]
+            }
+          })
+        );
+        expect(onResponseMock).toHaveBeenCalledTimes(1);
+        expect(onResponseMock).toBeCalledWith(
+          null,
+          expect.objectContaining({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            data: {
+              books: [1, 42, 150]
+            }
+          })
+        );
+
+        secondRun = true;
+        wrapper.setProps({
+          url: '/test/succeeds/json-two',
+          requestKey: '2'
+        });
+
+        // We do a network timeout here to ensure that the `expect` within
+        // render is called a second time.
+        setTimeout(() => {
+          done();
+        }, networkTimeout);
+      }, networkTimeout);
+    });
+
+    // test('it uses an indirectly-updated request key on subsequent renders', done => {
+    //   // expect.assertions(10);
+    //   const onResponseMock = jest.fn();
+    //   const beforeFetchMock = jest.fn();
+    //   const afterFetchMock = jest.fn();
+
+    //   let run = 1;
+
+    //   const wrapper = mount(
+    //     <Fetch
+    //       url="/test/succeeds/json-one"
+    //       beforeFetch={beforeFetchMock}
+    //       afterFetch={afterFetchMock}
+    //       onResponse={onResponseMock}>
+    //       {options => {
+    //         if (run === 1 && options.response) {
+    //           expect(options.data).toEqual({
+    //             books: [1, 42, 150]
+    //           });
+    //         }
+    //         if (run === 2 && options.fetching) {
+    //           expect(options.data).toEqual({
+    //             books: [1, 42, 150]
+    //           });
+    //         }
+
+    //         if (run === 2 && !options.fetching) {
+    //           expect(options.data).toEqual({
+    //             authors: [22, 13]
+    //           });
+    //         }
+
+    //         // With data from the cache, there is no in-between render
+    //         // for "loading." It just immediately gets set.
+    //         if (run === 3) {
+    //           expect(options.data).toEqual({
+    //             books: [1, 42, 150]
+    //           });
+    //         }
+    //       }}
+    //     </Fetch>
+    //   );
+
+    //   setTimeout(() => {
+    //     // NOTE: this is for adding stuff to the cache.
+    //     // This DOES NOT test the cache-only behavior!
+    //     expect(fetchMock.calls('/test/succeeds/json-one').length).toBe(1);
+    //     expect(beforeFetchMock).toHaveBeenCalledTimes(1);
+    //     expect(afterFetchMock).toHaveBeenCalledTimes(1);
+    //     expect(afterFetchMock).toBeCalledWith(
+    //       expect.objectContaining({
+    //         url: '/test/succeeds/json-one',
+    //         error: null,
+    //         failed: false,
+    //         didUnmount: false,
+    //         data: {
+    //           books: [1, 42, 150]
+    //         }
+    //       })
+    //     );
+    //     expect(onResponseMock).toHaveBeenCalledTimes(1);
+    //     expect(onResponseMock).toBeCalledWith(
+    //       null,
+    //       expect.objectContaining({
+    //         ok: true,
+    //         status: 200,
+    //         statusText: 'OK',
+    //         data: {
+    //           books: [1, 42, 150]
+    //         }
+    //       })
+    //     );
+
+    //     run = 2;
+    //     wrapper.setProps({
+    //       url: '/test/succeeds/json-two'
+    //     });
+
+    //     setTimeout(() => {
+    //       run = 3;
+    //       wrapper.setProps({
+    //         url: '/test/succeeds/json-one'
+    //       });
+
+    //       setTimeout(() => {
+    //         done();
+    //       }, 500);
+    //     }, 500);
+    //   }, networkTimeout);
+    // });
+  });
+
+  describe('doFetch', () => {});
+});

--- a/test/same-component.test.js
+++ b/test/same-component.test.js
@@ -2,24 +2,6 @@ import React from 'react';
 import fetchMock from 'fetch-mock';
 import { mount } from 'enzyme';
 import { Fetch, clearRequestCache, clearResponseCache } from '../src';
-import { jsonResponse, jsonResponse2 } from './responses';
-import { setTimeout } from 'timers';
-
-fetchMock.get(
-  '/test/succeeds/json-one',
-  () =>
-    new Promise(resolve => {
-      resolve(jsonResponse());
-    })
-);
-
-fetchMock.get(
-  '/test/succeeds/json-two',
-  () =>
-    new Promise(resolve => {
-      resolve(jsonResponse2());
-    })
-);
 
 // Some time for the mock fetches to resolve
 const networkTimeout = 10;
@@ -29,216 +11,298 @@ beforeEach(() => {
   clearResponseCache();
 });
 
+// Issue 151 describes the 3 situations when requests can be made. This tests
+//  situation 2.
 describe('same-component subsequent requests with caching (gh-151)', () => {
-  // Issue 151 describes the 3 situations when requests can be made. "Prop changes"
-  // refers to situation 2.
-  describe('prop changes', () => {
-    test('it uses a directly-updated request key on subsequent renders', done => {
-      // expect.assertions(8);
-      const onResponseMock = jest.fn();
-      const beforeFetchMock = jest.fn();
-      const afterFetchMock = jest.fn();
+  test('it uses a directly-updated request key on subsequent renders', done => {
+    // expect.assertions(8);
+    const onResponseMock = jest.fn();
+    const beforeFetchMock = jest.fn();
+    const afterFetchMock = jest.fn();
 
-      let secondRun = false;
-      let secondRenderCount = 0;
+    let run = 1;
+    let renderCount = 0;
 
-      const wrapper = mount(
-        <Fetch
-          url="/test/succeeds/json-one"
-          requestKey="1"
-          beforeFetch={beforeFetchMock}
-          afterFetch={afterFetchMock}
-          onResponse={onResponseMock}>
-          {options => {
-            if (secondRun) {
-              // Increment our render count. This allows us to
-              // test for each of the individual renders involved
-              // with changing the prop.
-              secondRenderCount++;
+    const wrapper = mount(
+      <Fetch
+        url="/test/succeeds/json-one"
+        requestKey="1"
+        beforeFetch={beforeFetchMock}
+        afterFetch={afterFetchMock}
+        onResponse={onResponseMock}>
+        {options => {
+          if (run === 2) {
+            // Increment our render count. This allows us to
+            // test for each of the individual renders involved
+            // with changing the prop.
+            renderCount++;
 
-              // This first render is interesting: we basically only have a
-              // new URL set, but the request has not yet begun. The reason
-              // for this is because we do the fetch in `componentDidUpdate`.
-              if (secondRenderCount === 1) {
-                expect(options).toEqual(
-                  expect.objectContaining({
-                    requestKey: '1',
-                    fetching: false,
-                    data: {
-                      books: [1, 42, 150]
-                    },
-                    error: null,
-                    failed: false,
-                    url: '/test/succeeds/json-two'
-                  })
-                );
-              } else if (secondRenderCount === 2) {
-                expect(options).toEqual(
-                  expect.objectContaining({
-                    requestKey: '2',
-                    fetching: true,
-                    data: {
-                      books: [1, 42, 150]
-                    },
-                    error: null,
-                    failed: false,
-                    url: '/test/succeeds/json-two'
-                  })
-                );
-              } else if (secondRenderCount === 3) {
-                expect(options).toEqual(
-                  expect.objectContaining({
-                    requestKey: '2',
-                    fetching: false,
-                    data: {
-                      authors: [22, 13]
-                    },
-                    error: null,
-                    failed: false,
-                    url: '/test/succeeds/json-two'
-                  })
-                );
-              }
+            // This first render is interesting: we basically only have a
+            // new URL set, but the request has not yet begun. The reason
+            // for this is because we do the fetch in `componentDidUpdate`.
+            if (renderCount === 1) {
+              expect(options).toEqual(
+                expect.objectContaining({
+                  requestKey: '1',
+                  fetching: false,
+                  data: {
+                    books: [1, 42, 150]
+                  },
+                  error: null,
+                  failed: false,
+                  url: '/test/succeeds/json-one'
+                })
+              );
+            } else if (renderCount === 2) {
+              expect(options).toEqual(
+                expect.objectContaining({
+                  requestKey: '2',
+                  fetching: true,
+                  data: {
+                    books: [1, 42, 150]
+                  },
+                  error: null,
+                  failed: false,
+                  url: '/test/succeeds/json-two'
+                })
+              );
+            } else if (renderCount === 3) {
+              expect(options).toEqual(
+                expect.objectContaining({
+                  requestKey: '2',
+                  fetching: false,
+                  data: {
+                    authors: [22, 13]
+                  },
+                  error: null,
+                  failed: false,
+                  url: '/test/succeeds/json-two'
+                })
+              );
+            } else if (renderCount > 3) {
+              done.fail();
             }
-          }}
-        </Fetch>
+          }
+        }}
+      </Fetch>
+    );
+
+    setTimeout(() => {
+      // NOTE: this is for adding stuff to the cache.
+      // This DOES NOT test the cache-only behavior!
+      expect(fetchMock.calls('/test/succeeds/json-one').length).toBe(1);
+      expect(beforeFetchMock).toHaveBeenCalledTimes(1);
+      expect(afterFetchMock).toHaveBeenCalledTimes(1);
+      expect(afterFetchMock).toBeCalledWith(
+        expect.objectContaining({
+          url: '/test/succeeds/json-one',
+          error: null,
+          failed: false,
+          didUnmount: false,
+          data: {
+            books: [1, 42, 150]
+          }
+        })
+      );
+      expect(onResponseMock).toHaveBeenCalledTimes(1);
+      expect(onResponseMock).toBeCalledWith(
+        null,
+        expect.objectContaining({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          data: {
+            books: [1, 42, 150]
+          }
+        })
       );
 
+      run = 2;
+      wrapper.setProps({
+        url: '/test/succeeds/json-two',
+        requestKey: '2'
+      });
+
+      // We do a network timeout here to ensure that the `expect` within
+      // render is called a second time.
       setTimeout(() => {
-        // NOTE: this is for adding stuff to the cache.
-        // This DOES NOT test the cache-only behavior!
-        expect(fetchMock.calls('/test/succeeds/json-one').length).toBe(1);
-        expect(beforeFetchMock).toHaveBeenCalledTimes(1);
-        expect(afterFetchMock).toHaveBeenCalledTimes(1);
-        expect(afterFetchMock).toBeCalledWith(
-          expect.objectContaining({
-            url: '/test/succeeds/json-one',
-            error: null,
-            failed: false,
-            didUnmount: false,
-            data: {
-              books: [1, 42, 150]
-            }
-          })
-        );
-        expect(onResponseMock).toHaveBeenCalledTimes(1);
-        expect(onResponseMock).toBeCalledWith(
-          null,
-          expect.objectContaining({
-            ok: true,
-            status: 200,
-            statusText: 'OK',
-            data: {
-              books: [1, 42, 150]
-            }
-          })
-        );
-
-        secondRun = true;
-        wrapper.setProps({
-          url: '/test/succeeds/json-two',
-          requestKey: '2'
-        });
-
-        // We do a network timeout here to ensure that the `expect` within
-        // render is called a second time.
-        setTimeout(() => {
-          done();
-        }, networkTimeout);
+        done();
       }, networkTimeout);
-    });
-
-    // test('it uses an indirectly-updated request key on subsequent renders', done => {
-    //   // expect.assertions(10);
-    //   const onResponseMock = jest.fn();
-    //   const beforeFetchMock = jest.fn();
-    //   const afterFetchMock = jest.fn();
-
-    //   let run = 1;
-
-    //   const wrapper = mount(
-    //     <Fetch
-    //       url="/test/succeeds/json-one"
-    //       beforeFetch={beforeFetchMock}
-    //       afterFetch={afterFetchMock}
-    //       onResponse={onResponseMock}>
-    //       {options => {
-    //         if (run === 1 && options.response) {
-    //           expect(options.data).toEqual({
-    //             books: [1, 42, 150]
-    //           });
-    //         }
-    //         if (run === 2 && options.fetching) {
-    //           expect(options.data).toEqual({
-    //             books: [1, 42, 150]
-    //           });
-    //         }
-
-    //         if (run === 2 && !options.fetching) {
-    //           expect(options.data).toEqual({
-    //             authors: [22, 13]
-    //           });
-    //         }
-
-    //         // With data from the cache, there is no in-between render
-    //         // for "loading." It just immediately gets set.
-    //         if (run === 3) {
-    //           expect(options.data).toEqual({
-    //             books: [1, 42, 150]
-    //           });
-    //         }
-    //       }}
-    //     </Fetch>
-    //   );
-
-    //   setTimeout(() => {
-    //     // NOTE: this is for adding stuff to the cache.
-    //     // This DOES NOT test the cache-only behavior!
-    //     expect(fetchMock.calls('/test/succeeds/json-one').length).toBe(1);
-    //     expect(beforeFetchMock).toHaveBeenCalledTimes(1);
-    //     expect(afterFetchMock).toHaveBeenCalledTimes(1);
-    //     expect(afterFetchMock).toBeCalledWith(
-    //       expect.objectContaining({
-    //         url: '/test/succeeds/json-one',
-    //         error: null,
-    //         failed: false,
-    //         didUnmount: false,
-    //         data: {
-    //           books: [1, 42, 150]
-    //         }
-    //       })
-    //     );
-    //     expect(onResponseMock).toHaveBeenCalledTimes(1);
-    //     expect(onResponseMock).toBeCalledWith(
-    //       null,
-    //       expect.objectContaining({
-    //         ok: true,
-    //         status: 200,
-    //         statusText: 'OK',
-    //         data: {
-    //           books: [1, 42, 150]
-    //         }
-    //       })
-    //     );
-
-    //     run = 2;
-    //     wrapper.setProps({
-    //       url: '/test/succeeds/json-two'
-    //     });
-
-    //     setTimeout(() => {
-    //       run = 3;
-    //       wrapper.setProps({
-    //         url: '/test/succeeds/json-one'
-    //       });
-
-    //       setTimeout(() => {
-    //         done();
-    //       }, 500);
-    //     }, 500);
-    //   }, networkTimeout);
-    // });
+    }, networkTimeout);
   });
 
-  describe('doFetch', () => {});
+  test('it uses an indirectly-updated request key on subsequent renders', done => {
+    // expect.assertions(10);
+    const onResponseMock = jest.fn();
+    const beforeFetchMock = jest.fn();
+    const afterFetchMock = jest.fn();
+
+    let run = 1;
+    let renderCount = 0;
+
+    const wrapper = mount(
+      <Fetch
+        url="/test/succeeds/json-one"
+        beforeFetch={beforeFetchMock}
+        afterFetch={afterFetchMock}
+        onResponse={onResponseMock}>
+        {(options) => {
+          renderCount++;
+          if (run === 1) {
+            if (renderCount === 1) {
+              expect(options).toEqual(expect.objectContaining({
+                fetching: false,
+                data: null,
+                error: null,
+                failed: false,
+                response: null,
+                requestName: 'anonymousRequest',
+                url: '/test/succeeds/json-one'
+              }));
+            } else if (renderCount === 2) {
+              expect(options).toEqual(expect.objectContaining({
+                fetching: true,
+                data: null,
+                error: null,
+                failed: false,
+                response: null,
+                requestName: 'anonymousRequest',
+                url: '/test/succeeds/json-one'
+              }));
+            } else if (renderCount === 3) {
+              expect(options).toEqual(expect.objectContaining({
+                fetching: false,
+                data: {
+                  books: [1, 42, 150]
+                },
+                error: null,
+                failed: false,
+                requestName: 'anonymousRequest',
+                url: '/test/succeeds/json-one'
+              }));
+            } else if (renderCount > 3) {
+              done.fail();
+            }
+          }
+          
+          else if (run === 2) {
+            if (renderCount === 1) {
+              expect(options).toEqual(expect.objectContaining({
+                fetching: false,
+                data: {
+                  books: [1, 42, 150]
+                },
+                error: null,
+                failed: false,
+                requestName: 'anonymousRequest',
+                url: '/test/succeeds/json-one'
+              }));
+            } else if (renderCount === 2) {
+              expect(options).toEqual(expect.objectContaining({
+                fetching: true,
+                data: {
+                  books: [1, 42, 150]
+                },
+                error: null,
+                failed: false,
+                requestName: 'anonymousRequest',
+                url: '/test/succeeds/json-two'
+              }));
+            } else if (renderCount === 3) {
+              expect(options).toEqual(expect.objectContaining({
+                fetching: false,
+                data: {
+                  authors: [22, 13]
+                },
+                error: null,
+                failed: false,
+                requestName: 'anonymousRequest',
+                url: '/test/succeeds/json-two'
+              }));
+            } else if (renderCount > 3) {
+              done.fail();
+            }
+          }
+
+          else if (run === 3) {
+            if (renderCount === 1) {
+              expect(options).toEqual(expect.objectContaining({
+                fetching: false,
+                data: {
+                  authors: [22, 13]
+                },
+                error: null,
+                failed: false,
+                requestName: 'anonymousRequest',
+                url: '/test/succeeds/json-two'
+              }));
+            }
+            else if (renderCount === 2) {
+              expect(options).toEqual(expect.objectContaining({
+                fetching: false,
+                data: {
+                  books: [1, 42, 150]
+                },
+                error: null,
+                failed: false,
+                requestName: 'anonymousRequest',
+                url: '/test/succeeds/json-one'
+              }));
+            } else if (renderCount > 2) {
+              done.fail();
+            }
+          }
+        }}
+      </Fetch>
+    );
+
+    setTimeout(() => {
+      // NOTE: this is for adding stuff to the cache.
+      // This DOES NOT test the cache-only behavior!
+      expect(fetchMock.calls('/test/succeeds/json-one').length).toBe(1);
+      expect(beforeFetchMock).toHaveBeenCalledTimes(1);
+      expect(afterFetchMock).toHaveBeenCalledTimes(1);
+      expect(afterFetchMock).toBeCalledWith(
+        expect.objectContaining({
+          url: '/test/succeeds/json-one',
+          error: null,
+          failed: false,
+          didUnmount: false,
+          data: {
+            books: [1, 42, 150]
+          }
+        })
+      );
+      expect(onResponseMock).toHaveBeenCalledTimes(1);
+      expect(onResponseMock).toBeCalledWith(
+        null,
+        expect.objectContaining({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          data: {
+            books: [1, 42, 150]
+          }
+        })
+      );
+
+      run = 2;
+      renderCount = 0;
+      wrapper.setProps({
+        url: '/test/succeeds/json-two'
+      });
+
+      setTimeout(() => {
+        run = 3;
+        renderCount = 0;
+        wrapper.setProps({
+          url: '/test/succeeds/json-one'
+        });
+
+        setTimeout(() => {
+          done();
+        }, 500);
+      }, 500);
+    }, networkTimeout);
+  });
 });

--- a/test/setup.js
+++ b/test/setup.js
@@ -2,12 +2,83 @@ import 'isomorphic-fetch';
 import fetchMock from 'fetch-mock';
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import {
+  successfulResponse, jsonResponse, jsonResponse2, jsonResponse3
+} from './responses';
 
 Enzyme.configure({ adapter: new Adapter() });
 
 // We need an AbortSignal that can be instantiated without
 // an error.
 global.AbortSignal = function() {};
+
+var hangingPromise = global.hangingPromise = function() {
+  return new Promise(() => {});
+}
+
+fetchMock.get('/test/hangs', hangingPromise());
+fetchMock.get('/test/hangs/1', hangingPromise());
+fetchMock.get('/test/hangs/2', hangingPromise());
+fetchMock.post('/test/hangs', hangingPromise());
+fetchMock.put('/test/hangs', hangingPromise());
+fetchMock.patch('/test/hangs', hangingPromise());
+fetchMock.head('/test/hangs', hangingPromise());
+fetchMock.delete('/test/hangs', hangingPromise());
+
+// This could be improved by adding the URL to the JSON response
+fetchMock.get('/test/succeeds', () => {
+  return new Promise(resolve => {
+    resolve(jsonResponse());
+  });
+});
+
+fetchMock.get(
+  '/test/succeeds/cache-only-empty',
+  () =>
+    new Promise(resolve => {
+      resolve(successfulResponse());
+    })
+);
+
+fetchMock.get(
+  '/test/succeeds/cache-only-full',
+  () =>
+    new Promise(resolve => {
+      resolve(jsonResponse());
+    })
+);
+
+fetchMock.post(
+  '/test/succeeds/cache-only-full',
+  () =>
+    new Promise(resolve => {
+      resolve(jsonResponse());
+    })
+);
+
+fetchMock.get(
+  '/test/succeeds/json-one',
+  () =>
+    new Promise(resolve => {
+      resolve(jsonResponse());
+    })
+);
+
+fetchMock.get(
+  '/test/succeeds/json-two',
+  () =>
+    new Promise(resolve => {
+      resolve(jsonResponse2());
+    })
+);
+
+fetchMock.patch(
+  '/test/succeeds/patch',
+  () =>
+    new Promise(resolve => {
+      resolve(jsonResponse3());
+    })
+);
 
 // We do this at the start of each test, just in case a test
 // replaces the global fetch and does not reset it


### PR DESCRIPTION
Resolves #151 . Supersedes #150 

This has been published as `react-request@2.0.4-beta.3`

#### Todo

- [x] Ensure generated request key from options is prioritized over this.props.requestKey. This will matter for `doFetch` when a new request key would be computed.
- [x] Ensure that the correct key is passed to render. This means that `setState` will need to be called to update the key.
- [x] Ensure `this.props` is not used within `fetchData`, or think up a better solution
- [x] Tests
  - [x] Ensure `doFetch` request key is prioritized over props
  - [x]  Ensure `doFetch` options are prioritized over props
  - [x] Ensure `doFetch` request cancellation behaves as expected
  - [x] Check URL1=>URL2=>URL1 with caching
- [x] Update code comments
- [x] Release
- [x] Deprecate older versions