### PR TITLE
Update fetch-dedupe to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "rollup-plugin-uglify": "^2.0.1"
   },
   "dependencies": {
-    "fetch-dedupe": "^2.1.0",
+    "fetch-dedupe": "^3.0.0",
     "prop-types": "^15.6.0"
   }
 }


### PR DESCRIPTION
Resolves #149 

This makes `responseType` more forgiving, which is something I know that everyone wants.

//cc @shanecav 😉 