### PR TITLE
3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+### v3.0.0 (2018/4/24)
+
+> Although the changes in this release are technically breaking, they are unlikely to
+> affect most users' code.
+
+**Breaking Changes**
+
+* When a request fails, the `data` from a request will no longer be set to `null`. This
+  allows you to control whether or not your UI continues to display the existing data.
+
+* The `responseType` prop is now more forgiving. If the body cannot be parsed with
+  the `responseType` that you set, then `data` will be set to `null`.
+
 ### v2.0.4 (2018/4/20)
 
 **Bug Fixes**

--- a/README.md
+++ b/README.md
@@ -364,30 +364,8 @@ about the response, such as its status code.
 </Fetch>
 ```
 
-```jsx
-// Some "enterprisey" endpoints return text stack traces anytime that they error. A function
-// `responseType` can protect you against this.
-<Fetch
-  url="/countries/2"
-  responseType={response => {
-    // Only parse as JSON when the request's code is not an error code, and it is
-    // not 204 No Content.
-    return response.ok && response.status !== 204 ? 'json' : 'text';
-  }}
-  transformData={countryName => {
-    return {
-      countryName
-    };
-  }}>
-  {({ data }) => {
-    if (data) {
-      return <div>{data.countryName}</div>;
-    }
-
-    return null;
-  }}
-</Fetch>
-```
+If the response body cannot be parsed as the `responseType` that you specify, then `data` will
+be set to `null`.
 
 ##### `requestName`
 

--- a/examples/fetch-components/package.json
+++ b/examples/fetch-components/package.json
@@ -6,7 +6,7 @@
     "react": "^16.2.0",
     "react-composer": "^4.1.0",
     "react-dom": "^16.2.0",
-    "react-request": "^2.0.4",
+    "react-request": "^3.0.0",
     "react-scripts": "1.1.0"
   },
   "scripts": {

--- a/examples/lazy-read/package.json
+++ b/examples/lazy-read/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-request": "^2.0.4",
+    "react-request": "^3.0.0",
     "react-scripts": "1.1.0"
   },
   "scripts": {

--- a/examples/multiple-requests/package.json
+++ b/examples/multiple-requests/package.json
@@ -6,7 +6,7 @@
     "react": "^16.2.0",
     "react-composer": "^4.1.0",
     "react-dom": "^16.2.0",
-    "react-request": "^2.0.4",
+    "react-request": "^3.0.0",
     "react-scripts": "1.1.0"
   },
   "scripts": {

--- a/examples/request-deduplication/package.json
+++ b/examples/request-deduplication/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-request": "^2.0.4",
+    "react-request": "^3.0.0",
     "react-scripts": "1.1.0"
   },
   "scripts": {

--- a/examples/response-caching/package.json
+++ b/examples/response-caching/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-request": "^2.0.4",
+    "react-request": "^3.0.0",
     "react-scripts": "1.1.0"
   },
   "scripts": {

--- a/examples/simple-read/package.json
+++ b/examples/simple-read/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-request": "^2.0.4",
+    "react-request": "^3.0.0",
     "react-scripts": "1.1.0"
   },
   "scripts": {

--- a/examples/updating-a-resource/package.json
+++ b/examples/updating-a-resource/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-request": "^2.0.4",
+    "react-request": "^3.0.0",
     "react-scripts": "1.1.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "rollup-plugin-uglify": "^2.0.1"
   },
   "dependencies": {
-    "fetch-dedupe": "^2.1.0",
+    "fetch-dedupe": "^3.0.0",
     "prop-types": "^15.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-request",
-  "version": "2.0.4",
+  "version": "3.0.0",
   "description": "Declarative HTTP requests with React.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -369,6 +369,14 @@ export class Fetch extends React.Component {
 
     data = data ? this.props.transformData(data) : null;
 
+    // If we already have some data in state on error, then we continue to
+    // pass that data down. This prevents the data from being wiped when a
+    // request fails, which is generally not what people want.
+    // For more, see: GitHub Issue #154
+    if (error && this.state.data) {
+      data = this.state.data;
+    }
+
     if (hittingNetwork) {
       this.props.afterFetch({
         url,

--- a/test/do-fetch.test.js
+++ b/test/do-fetch.test.js
@@ -37,16 +37,18 @@ describe('same-component doFetch() with caching (gh-151)', () => {
           // 2nd. fetch begins
           // 3rd. fetch ends
           if (run === 1 && renderCount === 3) {
-            expect(options).toEqual(expect.objectContaining({
-              fetching: false,
-              data: {
-                books: [1, 42, 150]
-              },
-              error: null,
-              failed: false,
-              requestName: 'anonymousRequest',
-              url: '/test/succeeds/json-one'
-            }));
+            expect(options).toEqual(
+              expect.objectContaining({
+                fetching: false,
+                data: {
+                  books: [1, 42, 150]
+                },
+                error: null,
+                failed: false,
+                requestName: 'anonymousRequest',
+                url: '/test/succeeds/json-one'
+              })
+            );
 
             // We need a timeout here to prevent a race condition
             // with the assertions after the component mounts.
@@ -68,29 +70,33 @@ describe('same-component doFetch() with caching (gh-151)', () => {
 
           if (run === 2) {
             if (renderCount === 1) {
-              expect(options).toEqual(expect.objectContaining({
-                fetching: true,
-                data: {
-                  books: [1, 42, 150]
-                },
-                error: null,
-                failed: false,
-                requestName: 'anonymousRequest',
-                url: '/test/succeeds/patch'
-              }));
+              expect(options).toEqual(
+                expect.objectContaining({
+                  fetching: true,
+                  data: {
+                    books: [1, 42, 150]
+                  },
+                  error: null,
+                  failed: false,
+                  requestName: 'anonymousRequest',
+                  url: '/test/succeeds/patch'
+                })
+              );
             }
             if (renderCount === 2) {
               expect(fetchMock.calls('/test/succeeds/patch').length).toBe(1);
-              expect(options).toEqual(expect.objectContaining({
-                fetching: false,
-                data: {
-                  movies: [1]
-                },
-                error: null,
-                failed: false,
-                requestName: 'anonymousRequest',
-                url: '/test/succeeds/patch'
-              }));
+              expect(options).toEqual(
+                expect.objectContaining({
+                  fetching: false,
+                  data: {
+                    movies: [1]
+                  },
+                  error: null,
+                  failed: false,
+                  requestName: 'anonymousRequest',
+                  url: '/test/succeeds/patch'
+                })
+              );
             }
             if (renderCount === 3) {
               done.fail();
@@ -157,16 +163,18 @@ describe('same-component doFetch() with caching (gh-151)', () => {
           // 2nd. fetch begins
           // 3rd. fetch ends
           if (run === 1 && renderCount === 3) {
-            expect(options).toEqual(expect.objectContaining({
-              fetching: false,
-              data: {
-                books: [1, 42, 150]
-              },
-              error: null,
-              failed: false,
-              requestName: 'anonymousRequest',
-              url: '/test/succeeds/json-one'
-            }));
+            expect(options).toEqual(
+              expect.objectContaining({
+                fetching: false,
+                data: {
+                  books: [1, 42, 150]
+                },
+                error: null,
+                failed: false,
+                requestName: 'anonymousRequest',
+                url: '/test/succeeds/json-one'
+              })
+            );
 
             // We need a timeout here to prevent a race condition
             // with the assertions after the component mounts.
@@ -189,30 +197,34 @@ describe('same-component doFetch() with caching (gh-151)', () => {
 
           if (run === 2) {
             if (renderCount === 1) {
-              expect(options).toEqual(expect.objectContaining({
-                fetching: true,
-                data: {
-                  books: [1, 42, 150]
-                },
-                error: null,
-                failed: false,
-                requestKey: 'sandwiches',
-                requestName: 'anonymousRequest',
-                url: '/test/succeeds/json-two'
-              }));
+              expect(options).toEqual(
+                expect.objectContaining({
+                  fetching: true,
+                  data: {
+                    books: [1, 42, 150]
+                  },
+                  error: null,
+                  failed: false,
+                  requestKey: 'sandwiches',
+                  requestName: 'anonymousRequest',
+                  url: '/test/succeeds/json-two'
+                })
+              );
             }
             if (renderCount === 2) {
-              expect(options).toEqual(expect.objectContaining({
-                fetching: false,
-                data: {
-                  authors: [22, 13]
-                },
-                error: null,
-                failed: false,
-                requestKey: 'sandwiches',
-                requestName: 'anonymousRequest',
-                url: '/test/succeeds/json-two'
-              }));
+              expect(options).toEqual(
+                expect.objectContaining({
+                  fetching: false,
+                  data: {
+                    authors: [22, 13]
+                  },
+                  error: null,
+                  failed: false,
+                  requestKey: 'sandwiches',
+                  requestName: 'anonymousRequest',
+                  url: '/test/succeeds/json-two'
+                })
+              );
             }
             if (renderCount === 3) {
               done.fail();
@@ -281,16 +293,18 @@ describe('same-component doFetch() with caching (gh-151)', () => {
           // 2nd. fetch begins
           // 3rd. fetch ends
           if (run === 1 && renderCount === 3) {
-            expect(options).toEqual(expect.objectContaining({
-              fetching: false,
-              data: {
-                books: [1, 42, 150]
-              },
-              error: null,
-              failed: false,
-              requestName: 'anonymousRequest',
-              url: '/test/succeeds/json-one'
-            }));
+            expect(options).toEqual(
+              expect.objectContaining({
+                fetching: false,
+                data: {
+                  books: [1, 42, 150]
+                },
+                error: null,
+                failed: false,
+                requestName: 'anonymousRequest',
+                url: '/test/succeeds/json-one'
+              })
+            );
 
             // We need a timeout here to prevent a race condition
             // with the assertions after the component mounts.
@@ -318,57 +332,65 @@ describe('same-component doFetch() with caching (gh-151)', () => {
 
           if (run === 2) {
             if (renderCount === 1) {
-              expect(options).toEqual(expect.objectContaining({
-                fetching: true,
-                data: {
-                  books: [1, 42, 150]
-                },
-                error: null,
-                failed: false,
-                requestKey: 'sandwiches',
-                requestName: 'anonymousRequest',
-                url: '/test/succeeds/json-two'
-              }));
+              expect(options).toEqual(
+                expect.objectContaining({
+                  fetching: true,
+                  data: {
+                    books: [1, 42, 150]
+                  },
+                  error: null,
+                  failed: false,
+                  requestKey: 'sandwiches',
+                  requestName: 'anonymousRequest',
+                  url: '/test/succeeds/json-two'
+                })
+              );
             }
             if (renderCount === 2) {
-              expect(options).toEqual(expect.objectContaining({
-                fetching: false,
-                // I am not sure if I like this behavior!
-                // See gh-154 for more
-                data: null,
-                failed: true,
-                requestKey: 'sandwiches',
-                requestName: 'anonymousRequest',
-                url: '/test/succeeds/json-two'
-              }));
+              expect(options).toEqual(
+                expect.objectContaining({
+                  fetching: false,
+                  data: {
+                    books: [1, 42, 150]
+                  },
+                  failed: true,
+                  requestKey: 'sandwiches',
+                  requestName: 'anonymousRequest',
+                  url: '/test/succeeds/json-two'
+                })
+              );
             }
 
             // This is the 2nd doFetch(). It is difficult to update
             // the `run` for that fetch, so we just use the renderCounts.
             else if (renderCount === 3) {
-              expect(options).toEqual(expect.objectContaining({
-                fetching: true,
-                data: null,
-                error: null,
-                failed: false,
-                requestKey: 'sandwiches',
-                requestName: 'anonymousRequest',
-                url: '/test/succeeds/json-two'
-              }));
-            }
-
-            else if (renderCount === 4) {
-              expect(options).toEqual(expect.objectContaining({
-                fetching: false,
-                data: {
-                  authors: [22, 13]
-                },
-                error: null,
-                failed: false,
-                requestKey: 'sandwiches',
-                requestName: 'anonymousRequest',
-                url: '/test/succeeds/json-two'
-              }));
+              expect(options).toEqual(
+                expect.objectContaining({
+                  fetching: true,
+                  data: {
+                    books: [1, 42, 150]
+                  },
+                  error: null,
+                  failed: false,
+                  requestKey: 'sandwiches',
+                  requestName: 'anonymousRequest',
+                  url: '/test/succeeds/json-two'
+                })
+              );
+            } else if (renderCount === 4) {
+              expect(options).toEqual(
+                expect.objectContaining({
+                  fetching: false,
+                  data: {
+                    authors: [22, 13]
+                  },
+                  error: null,
+                  failed: false,
+                  requestKey: 'sandwiches',
+                  requestName: 'anonymousRequest',
+                  url: '/test/succeeds/json-two'
+                })
+              );
             }
             if (renderCount > 4) {
               done.fail();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -212,6 +212,40 @@ describe('successful requests', () => {
     }, networkTimeout);
   });
 
+  test('it sets data to `null` if the contentType does not parse the data', done => {
+    fetchMock.get(
+      '/test/succeeds/second-mismatch-content-type',
+      new Promise(resolve => {
+        resolve(successfulResponse());
+      })
+    );
+
+    expect.assertions(2);
+    const afterFetchMock = jest.fn();
+
+    mount(
+      <Fetch
+        url="/test/succeeds/second-mismatch-content-type"
+        afterFetch={afterFetchMock}
+        responseType="json"
+      />
+    );
+
+    setTimeout(() => {
+      expect(afterFetchMock).toHaveBeenCalledTimes(1);
+      expect(afterFetchMock).toBeCalledWith(
+        expect.objectContaining({
+          url: '/test/succeeds/second-mismatch-content-type',
+          error: null,
+          failed: false,
+          didUnmount: false,
+          data: null
+        })
+      );
+      done();
+    }, networkTimeout);
+  });
+
   test('it accepts a custom `responseType` as a function, and calls afterFetch with the right arguments', done => {
     fetchMock.get(
       '/test/succeeds/secondpls',


### PR DESCRIPTION
A bunch of stuff in this release is thanks to @shanecav :v:

Todo:

#### Code stuff
- [x] Update fetch-dedupe to v3  ( #158 #149 )
- [ ] ~~Make `doFetch` return a Promise ( #146 )~~
- [x] No longer _necessarily_ wipe data on fails ( #154 )

#### Docs stuff

- [x] Update documentation with the more forgiving `responseType` prop in mind
- [ ] ~~Update `doFetch` docs~~
- [x] Update examples

#### Target release date

Sometime in the next week.