### PR TITLE
Allow react 17 as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "es"
   ],
   "peerDependencies": {
-    "react": "^15.0.0 || ^16.0.0"
+    "react": "^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
To prevent peerDependency warnings when using React 17.

The enzyme-adapter-react-17 is not yet released, so tests can't be yet updated to use React 17.